### PR TITLE
Add basic testing setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,15 @@
     "react-scripts": "5.0.1",
     "recharts": "^2.15.3"
   },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.1.3",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject"
   },
   "browserslist": {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import App from './App';
+
+test('renders calculator heading', () => {
+  render(<App />);
+  const headingElement = screen.getByText(/Lorcana Ink Curve Calculator/i);
+  expect(headingElement).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- install React Testing Library dependencies
- add a simple `<App />` test
- run tests with `react-scripts test --watchAll=false`

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ac775204832db4dc84732d760c9d