### PR TITLE
Fix 126 error running npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "@testing-library/user-event": "^14.4.3"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --watchAll=false",
-    "eject": "react-scripts eject"
+    "start": "node node_modules/react-scripts/scripts/start.js",
+    "build": "node node_modules/react-scripts/scripts/build.js",
+    "test": "node node_modules/react-scripts/scripts/test.js --watchAll=false",
+    "eject": "node node_modules/react-scripts/scripts/eject.js"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary
- call react-scripts via `node` to avoid permission problems

## Testing
- `npm test` *(fails: Cannot find module 'react-scripts')*

------
https://chatgpt.com/codex/tasks/task_e_684409bc1414832d9993a7f91aa1fc27