### PR TITLE
Fix inkable count calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project is a simple React application for planning Lorcana deck ink curves. It allows you to input card costs and see how many inkables you should include for a desired success rate.
 
+The "Override Inkables" field lets you specify the exact number of inkable cards in your deck. If left blank, the calculator assumes any cards not accounted for in the cost breakdown are inkables. The recommended maximum number of non‑inkables is computed based on the target success rate, while the displayed success rate reflects your actual inkable count.
+
 ## Development
 
 Install dependencies and start a local dev server:

--- a/src/InkCurveCalculator.jsx
+++ b/src/InkCurveCalculator.jsx
@@ -42,16 +42,21 @@ export default function InkCurveCalculator() {
     const estimatedInkables = deckSize - totalCards;
     const inkablesInDeck = manualInkables !== "" ? Number(manualInkables) : estimatedInkables;
 
+    const currentProbability =
+      1 - cumulativeHypergeometric(targetTurn - 1, deckSize, inkablesInDeck, cardsSeen);
+
     let inkablesNeeded = 0;
-    let probability = 0;
 
     for (let inkables = 1; inkables <= deckSize; inkables++) {
-      probability = 1 - cumulativeHypergeometric(targetTurn - 1, deckSize, inkables, cardsSeen);
-      if (probability >= targetAccuracy / 100) {
+      const reqProb =
+        1 - cumulativeHypergeometric(targetTurn - 1, deckSize, inkables, cardsSeen);
+      if (reqProb >= targetAccuracy / 100) {
         inkablesNeeded = inkables;
         break;
       }
     }
+
+    const probability = currentProbability;
 
     const maxNonInkables = deckSize - inkablesNeeded;
 


### PR DESCRIPTION
## Summary
- fix deck calculation logic so probability uses deck's inkable count
- document how the Override Inkables field works

## Testing
- `npm test` *(fails: Cannot find module 'react-scripts/scripts/test.js')*

------
https://chatgpt.com/codex/tasks/task_e_6844aaa8fa84832da21763deef38e48a